### PR TITLE
prioritizeQueue

### DIFF
--- a/BrewMesModulesParent/api/src/main/java/com/brewmes/api/ScheduleController.java
+++ b/BrewMesModulesParent/api/src/main/java/com/brewmes/api/ScheduleController.java
@@ -50,7 +50,18 @@ public class ScheduleController {
         }
     }
 
-    @PatchMapping("/{id}/prioUp")
+    @PatchMapping("/prioritizeQueue")
+    public ResponseEntity<Object> prioritizeQueue(List<String> prioritizedList) {
+        boolean success = scheduleService.prioritizeQueue(prioritizedList);
+
+        if (success) {
+            return new ResponseEntity<>("Queue has been updated based on the prioritization", HttpStatus.OK);
+        } else {
+            return new ResponseEntity<>("Error: Queue has not been prioritized", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+/*    @PatchMapping("/{id}/prioUp")
     public ResponseEntity<String> prioritizeUpInQueue(@PathVariable String id) {
         boolean success = scheduleService.moveUpInQueue(id);
 
@@ -70,5 +81,5 @@ public class ScheduleController {
         } else {
             return new ResponseEntity<>("Error: Batch was not reprioritized", HttpStatus.INTERNAL_SERVER_ERROR);
         }
-    }
+    }*/
 }

--- a/BrewMesModulesParent/api/src/main/java/com/brewmes/api/ScheduleController.java
+++ b/BrewMesModulesParent/api/src/main/java/com/brewmes/api/ScheduleController.java
@@ -60,26 +60,4 @@ public class ScheduleController {
             return new ResponseEntity<>("Error: Queue has not been prioritized", HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
-
-/*    @PatchMapping("/{id}/prioUp")
-    public ResponseEntity<String> prioritizeUpInQueue(@PathVariable String id) {
-        boolean success = scheduleService.moveUpInQueue(id);
-
-        if (success) {
-            return new ResponseEntity<>("Batch was moved up in the queue", HttpStatus.OK);
-        } else {
-            return new ResponseEntity<>("Error: Batch was not reprioritized", HttpStatus.INTERNAL_SERVER_ERROR);
-        }
-    }
-
-    @PatchMapping("/{id}/prioDown")
-    public ResponseEntity<String> prioritizeDownInQueue(@PathVariable String id) {
-        boolean success = scheduleService.moveDownInQueue(id);
-
-        if (success) {
-            return new ResponseEntity<>("Batch was moved down in the queue", HttpStatus.OK);
-        } else {
-            return new ResponseEntity<>("Error: Batch was not reprioritized", HttpStatus.INTERNAL_SERVER_ERROR);
-        }
-    }*/
 }

--- a/BrewMesModulesParent/api/src/main/java/com/brewmes/api/ScheduleController.java
+++ b/BrewMesModulesParent/api/src/main/java/com/brewmes/api/ScheduleController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.Arrays;
 import java.util.List;
 
 @RestController
@@ -51,8 +52,8 @@ public class ScheduleController {
     }
 
     @PatchMapping("/prioritizeQueue")
-    public ResponseEntity<Object> prioritizeQueue(List<String> prioritizedList) {
-        boolean success = scheduleService.prioritizeQueue(prioritizedList);
+    public ResponseEntity<Object> prioritizeQueue(@RequestBody @Valid ScheduledBatch[] prioritizedList) {
+        boolean success = scheduleService.prioritizeQueue(Arrays.asList(prioritizedList));
 
         if (success) {
             return new ResponseEntity<>("Queue has been updated based on the prioritization", HttpStatus.OK);

--- a/BrewMesModulesParent/api/src/test/java/com/brewmes/api/ScheduleControllerTest.java
+++ b/BrewMesModulesParent/api/src/test/java/com/brewmes/api/ScheduleControllerTest.java
@@ -11,7 +11,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
@@ -25,7 +25,7 @@ class ScheduleControllerTest {
     @InjectMocks
     ScheduleController controller;
 
-    private final List<String> prioQueue = new ArrayList<>();
+    private final ScheduledBatch[] prioQueue = new ScheduledBatch[3];
 
     @Test
     void addToQueue() {
@@ -70,7 +70,7 @@ class ScheduleControllerTest {
 
     @Test
     void prioritizeQueue_succes() {
-        when(service.prioritizeQueue(prioQueue)).thenReturn(true);
+        when(service.prioritizeQueue(Arrays.asList(prioQueue))).thenReturn(true);
         ResponseEntity<Object> responseEntity = controller.prioritizeQueue(prioQueue);
 
         assertEquals(200, responseEntity.getStatusCode().value());
@@ -79,7 +79,7 @@ class ScheduleControllerTest {
 
     @Test
     void prioritizeQueue_failure() {
-        when(service.prioritizeQueue(prioQueue)).thenReturn(false);
+        when(service.prioritizeQueue(Arrays.asList(prioQueue))).thenReturn(false);
         ResponseEntity<Object> responseEntity = controller.prioritizeQueue(prioQueue);
 
         assertEquals(500, responseEntity.getStatusCode().value());

--- a/BrewMesModulesParent/api/src/test/java/com/brewmes/api/ScheduleControllerTest.java
+++ b/BrewMesModulesParent/api/src/test/java/com/brewmes/api/ScheduleControllerTest.java
@@ -7,13 +7,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ScheduleControllerTest {
@@ -24,13 +25,15 @@ class ScheduleControllerTest {
     @InjectMocks
     ScheduleController controller;
 
+    private final List<String> prioQueue = new ArrayList<>();
+
     @Test
     void addToQueue() {
         ScheduledBatch scheduledBatch = new ScheduledBatch(100, Products.ALE, 100);
         ScheduledBatch scheduledBatch1 = new ScheduledBatch(100, Products.ALCOHOL_FREE, 1);
 
-        Mockito.when(service.addToQueue(scheduledBatch)).thenReturn(1);
-        Mockito.when(service.addToQueue(scheduledBatch1)).thenReturn(-1);
+        when(service.addToQueue(scheduledBatch)).thenReturn(1);
+        when(service.addToQueue(scheduledBatch1)).thenReturn(-1);
 
         ResponseEntity<String> response = controller.addToQueue(scheduledBatch);
         ResponseEntity<String> response1 = controller.addToQueue(scheduledBatch1);
@@ -41,8 +44,8 @@ class ScheduleControllerTest {
 
     @Test
     void removeFromQueue() {
-        Mockito.when(service.removeFromQueue("goodID")).thenReturn(true);
-        Mockito.when(service.removeFromQueue("badID")).thenReturn(false);
+        when(service.removeFromQueue("goodID")).thenReturn(true);
+        when(service.removeFromQueue("badID")).thenReturn(false);
 
         ResponseEntity<String> response = controller.removeFromQueue("goodID");
         ResponseEntity<String> response1 = controller.removeFromQueue("badID");
@@ -54,37 +57,31 @@ class ScheduleControllerTest {
     @Test
     void getQueue() {
         //Checks the best case scenario where a list is actually returned
-        Mockito.when(service.getQueue()).thenReturn(new ArrayList<ScheduledBatch>());
+        when(service.getQueue()).thenReturn(new ArrayList<ScheduledBatch>());
         ResponseEntity<Object> response = controller.getQueue();
         assertEquals(200, response.getStatusCode().value());
 
         //Checks the worst case scenario where some error has happened in the backend and thereby it has returned null to the controller
-        Mockito.when(service.getQueue()).thenReturn(null);
+        when(service.getQueue()).thenReturn(null);
         response = controller.getQueue();
         assertEquals(500, response.getStatusCode().value());
     }
 
+
     @Test
-    void prioritizeUpInQueue() {
-        Mockito.when(service.moveUpInQueue("goodID")).thenReturn(true);
-        Mockito.when(service.moveUpInQueue("badID")).thenReturn(false);
+    void prioritizeQueue_succes() {
+        when(service.prioritizeQueue(prioQueue)).thenReturn(true);
+        ResponseEntity<Object> responseEntity = controller.prioritizeQueue(prioQueue);
 
-        ResponseEntity<String> response = controller.prioritizeUpInQueue("goodID");
-        ResponseEntity<String> response1 = controller.prioritizeUpInQueue("badID");
-
-        assertEquals(200, response.getStatusCode().value());
-        assertEquals(500, response1.getStatusCode().value());
+        assertEquals(200, responseEntity.getStatusCode().value());
     }
 
+
     @Test
-    void prioritizeDownInQueue() {
-        Mockito.when(service.moveDownInQueue("goodID")).thenReturn(true);
-        Mockito.when(service.moveDownInQueue("badID")).thenReturn(false);
+    void prioritizeQueue_failure() {
+        when(service.prioritizeQueue(prioQueue)).thenReturn(false);
+        ResponseEntity<Object> responseEntity = controller.prioritizeQueue(prioQueue);
 
-        ResponseEntity<String> response = controller.prioritizeDownInQueue("goodID");
-        ResponseEntity<String> response1 = controller.prioritizeDownInQueue("badID");
-
-        assertEquals(200, response.getStatusCode().value());
-        assertEquals(500, response1.getStatusCode().value());
+        assertEquals(500, responseEntity.getStatusCode().value());
     }
 }

--- a/BrewMesModulesParent/common/src/main/java/com/brewmes/common/services/IScheduleService.java
+++ b/BrewMesModulesParent/common/src/main/java/com/brewmes/common/services/IScheduleService.java
@@ -44,19 +44,10 @@ public interface IScheduleService {
     boolean queueIsEmpty();
 
     /**
-     * Moves the {@code ScheduledBatch} up in the queue by one spot. If the batch was number 4 in the queue, it will now be number 3.
+     * Prioritizes {@code ScheduledBatch} in the queue based on the list.
      *
-     * @param scheduleID a {@code ScheduledBatch}'s ID.
-     * @return {@code True} if the {@code ScheduledBatch} was moved; {@code False} if an error occurred.
+     * @param prioritizedIDList a {@code list} of {@code ScheduledBatch} IDs.
+     * @return {@code True} if the prioritization was successful; {@code False} if an error occurred.
      */
-    boolean moveUpInQueue(String scheduleID);
-
-    /**
-     * Moves the {@code ScheduledBatch} down in the queue by one spot. If the batch was number 2 in the queue, it will now be number 3.
-     *
-     * @param scheduleID a {@code ScheduledBatch}'s ID.
-     * @return {@code True} if the {@code ScheduledBatch} was moved; {@code False} if an error occurred.
-     */
-    boolean moveDownInQueue(String scheduleID);
-
+    boolean prioritizeQueue(List<String> prioritizedIDList);
 }

--- a/BrewMesModulesParent/common/src/main/java/com/brewmes/common/services/IScheduleService.java
+++ b/BrewMesModulesParent/common/src/main/java/com/brewmes/common/services/IScheduleService.java
@@ -49,5 +49,5 @@ public interface IScheduleService {
      * @param prioritizedIDList a {@code list} of {@code ScheduledBatch} IDs.
      * @return {@code True} if the prioritization was successful; {@code False} if an error occurred.
      */
-    boolean prioritizeQueue(List<String> prioritizedIDList);
+    boolean prioritizeQueue(List<ScheduledBatch> prioritizedIDList);
 }


### PR DESCRIPTION
Closes #81 #82

## Description
A new method to prioritize the queue is added, that takes a list of prioritized ScheduleBatch IDs. 
The moveUpInQueue and moveDownInQueue methods are removed.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes, if necessary.
- [x] All tests pass (existing and potential new).
- [x] Sonar check has passed
- [x] No codesmells or bugs

## Other Relevant Information

