### PR TITLE
Move enums containing the nodeId for the machine

### DIFF
--- a/BrewMesModulesParent/common/pom.xml
+++ b/BrewMesModulesParent/common/pom.xml
@@ -28,6 +28,11 @@
 			<version>3.1.8</version>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.eclipse.milo</groupId>
+			<artifactId>stack-core</artifactId>
+			<version>0.5.2</version>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/BrewMesModulesParent/common/src/main/java/com/brewmes/common/util/machinenodes/AdminNodes.java
+++ b/BrewMesModulesParent/common/src/main/java/com/brewmes/common/util/machinenodes/AdminNodes.java
@@ -1,4 +1,4 @@
-package com.brewmes.subscriber.util;
+package com.brewmes.common.util.machinenodes;
 
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 

--- a/BrewMesModulesParent/common/src/main/java/com/brewmes/common/util/machinenodes/CommandNodes.java
+++ b/BrewMesModulesParent/common/src/main/java/com/brewmes/common/util/machinenodes/CommandNodes.java
@@ -1,4 +1,4 @@
-package com.brewmes.subscriber.util;
+package com.brewmes.common.util.machinenodes;
 
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 

--- a/BrewMesModulesParent/common/src/main/java/com/brewmes/common/util/machinenodes/Constants.java
+++ b/BrewMesModulesParent/common/src/main/java/com/brewmes/common/util/machinenodes/Constants.java
@@ -1,4 +1,4 @@
-package com.brewmes.subscriber.util;
+package com.brewmes.common.util.machinenodes;
 
 class Constants {
     public static final int NAMESPACE_INDEX_VALUE = 6;

--- a/BrewMesModulesParent/common/src/main/java/com/brewmes/common/util/machinenodes/MachineNodes.java
+++ b/BrewMesModulesParent/common/src/main/java/com/brewmes/common/util/machinenodes/MachineNodes.java
@@ -1,4 +1,4 @@
-package com.brewmes.subscriber.util;
+package com.brewmes.common.util.machinenodes;
 
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 

--- a/BrewMesModulesParent/common/src/main/java/com/brewmes/common/util/machinenodes/StatusNodes.java
+++ b/BrewMesModulesParent/common/src/main/java/com/brewmes/common/util/machinenodes/StatusNodes.java
@@ -1,4 +1,4 @@
-package com.brewmes.subscriber.util;
+package com.brewmes.common.util.machinenodes;
 
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 

--- a/BrewMesModulesParent/common/src/test/java/com/brewmes/common/util/machinenodes/AdminNodesTest.java
+++ b/BrewMesModulesParent/common/src/test/java/com/brewmes/common/util/machinenodes/AdminNodesTest.java
@@ -1,4 +1,4 @@
-package com.brewmes.subscriber.util;
+package com.brewmes.common.util.machinenodes;
 
 import org.junit.jupiter.api.Test;
 

--- a/BrewMesModulesParent/common/src/test/java/com/brewmes/common/util/machinenodes/CommandNodesTest.java
+++ b/BrewMesModulesParent/common/src/test/java/com/brewmes/common/util/machinenodes/CommandNodesTest.java
@@ -1,4 +1,4 @@
-package com.brewmes.subscriber.util;
+package com.brewmes.common.util.machinenodes;
 
 import org.junit.jupiter.api.Test;
 

--- a/BrewMesModulesParent/common/src/test/java/com/brewmes/common/util/machinenodes/MachineNodesTest.java
+++ b/BrewMesModulesParent/common/src/test/java/com/brewmes/common/util/machinenodes/MachineNodesTest.java
@@ -1,4 +1,4 @@
-package com.brewmes.subscriber.util;
+package com.brewmes.common.util.machinenodes;
 
 import org.junit.jupiter.api.Test;
 

--- a/BrewMesModulesParent/common/src/test/java/com/brewmes/common/util/machinenodes/StatusNodesTest.java
+++ b/BrewMesModulesParent/common/src/test/java/com/brewmes/common/util/machinenodes/StatusNodesTest.java
@@ -1,4 +1,4 @@
-package com.brewmes.subscriber.util;
+package com.brewmes.common.util.machinenodes;
 
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
## Description
Move the enums to the common package such that they can be used both by the machine and subscriber

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes, if necessary.
- [ ] All tests pass (existing and potential new).
- [ ] Sonar check has passed
- [ ] No codesmells or bugs
