### PR TITLE
Remove required=false

### DIFF
--- a/BrewMesModulesParent/api/src/main/java/com/brewmes/api/ScheduleController.java
+++ b/BrewMesModulesParent/api/src/main/java/com/brewmes/api/ScheduleController.java
@@ -15,7 +15,7 @@ import java.util.List;
 @RequestMapping("/api/scheduled-batches")
 public class ScheduleController {
 
-    @Autowired(required = false)
+    @Autowired
     IScheduleService scheduleService;
 
     @PostMapping

--- a/BrewMesModulesParent/schedule/src/main/java/com/brewmes/schedule/ScheduleServiceImpl.java
+++ b/BrewMesModulesParent/schedule/src/main/java/com/brewmes/schedule/ScheduleServiceImpl.java
@@ -4,9 +4,11 @@ import com.brewmes.common.entities.ScheduledBatch;
 import com.brewmes.common.services.IScheduleService;
 import com.brewmes.common_repository.ScheduleRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+@Service
 public class ScheduleServiceImpl implements IScheduleService {
 
     @Autowired


### PR DESCRIPTION
Add service annotation to scheduleServiceImpl

Closes #65 

## Description
Removes `(requires=false)` from the schedule controller. 

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes, if necessary.
- [x] All tests pass (existing and potentially new).
- [x] Sonar check has passed
- [x] No code smells or bugs

## Other Relevant Information
None.
