### PR TITLE
Fix setAvg, setMax, setMin methods

### DIFF
--- a/BrewMesModulesParent/batch/src/main/java/com/brewmes/batch/PrepareData.java
+++ b/BrewMesModulesParent/batch/src/main/java/com/brewmes/batch/PrepareData.java
@@ -6,6 +6,7 @@ import com.brewmes.common.services.IBatchReportService;
 import com.brewmes.common.util.Products;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,16 +18,16 @@ public abstract class PrepareData implements IBatchReportService {
         return ((acceptedProducts * idealCycleTime) / plannedProductionTime) * 100;
     }
 
-    private double findAvgValueInMap(Map<LocalDateTime, Double> valueMap) {
-        return valueMap.values().stream().mapToDouble(Double::doubleValue).average().orElse(0);
+    private double findAvgValueInMap(List<Double> valueMap) {
+        return valueMap.stream().mapToDouble(Double::doubleValue).average().orElse(0);
     }
 
-    private double findMinValueInMap(Map<LocalDateTime, Double> valueMap) {
-        return valueMap.values().stream().mapToDouble(Double::doubleValue).min().orElse(0);
+    private double findMinValueInMap(List<Double> valueMap) {
+        return valueMap.stream().mapToDouble(Double::doubleValue).min().orElse(0);
     }
 
-    private double findMaxValueInMap(Map<LocalDateTime, Double> valueMap) {
-        return valueMap.values().stream().mapToDouble(Double::doubleValue).max().orElse(0);
+    private double findMaxValueInMap(List<Double> valueMap) {
+        return valueMap.stream().mapToDouble(Double::doubleValue).max().orElse(0);
     }
 
 
@@ -39,14 +40,14 @@ public abstract class PrepareData implements IBatchReportService {
         DataOverTime dot = new DataOverTime();
         dot.setBatch(batchData);
         List<MachineData> machineData = dot.getBatch().getData();
-        Map<LocalDateTime, Double> tempList = new LinkedHashMap<>();
-        Map<LocalDateTime, Double> vibList = new LinkedHashMap<>();
-        Map<LocalDateTime, Double> humList = new LinkedHashMap<>();
+        List<Double> tempList = new ArrayList<>();
+        List<Double> vibList = new ArrayList<>();
+        List<Double> humList = new ArrayList<>();
 
         for (MachineData data : machineData) {
-            tempList.put(data.getTimestamp(), data.getTemperature());
-            vibList.put(data.getTimestamp(), data.getVibration());
-            humList.put(data.getTimestamp(), data.getHumidity());
+            tempList.add(data.getTemperature());
+            vibList.add(data.getVibration());
+            humList.add(data.getHumidity());
         }
 
         dot.setAvgTemp(findAvgValueInMap(tempList));

--- a/BrewMesModulesParent/batch/src/main/java/com/brewmes/batch/PrepareData.java
+++ b/BrewMesModulesParent/batch/src/main/java/com/brewmes/batch/PrepareData.java
@@ -15,16 +15,16 @@ public abstract class PrepareData implements IBatchReportService {
         return ((acceptedProducts * idealCycleTime) / plannedProductionTime) * 100;
     }
 
-    private double findAvgValueInMap(List<Double> valueMap) {
-        return valueMap.stream().mapToDouble(Double::doubleValue).average().orElse(0);
+    private double findAvgValueInList(List<Double> valueList) {
+        return valueList.stream().mapToDouble(Double::doubleValue).average().orElse(0);
     }
 
-    private double findMinValueInMap(List<Double> valueMap) {
-        return valueMap.stream().mapToDouble(Double::doubleValue).min().orElse(0);
+    private double findMinValueInList(List<Double> valueList) {
+        return valueList.stream().mapToDouble(Double::doubleValue).min().orElse(0);
     }
 
-    private double findMaxValueInMap(List<Double> valueMap) {
-        return valueMap.stream().mapToDouble(Double::doubleValue).max().orElse(0);
+    private double findMaxValueInList(List<Double> valueList) {
+        return valueList.stream().mapToDouble(Double::doubleValue).max().orElse(0);
     }
 
 
@@ -48,17 +48,17 @@ public abstract class PrepareData implements IBatchReportService {
             humList.add(data.getHumidity());
         }
 
-        dot.setAvgTemp(findAvgValueInMap(tempList));
-        dot.setMaxTemp(findMaxValueInMap(tempList));
-        dot.setMinTemp(findMinValueInMap(tempList));
+        dot.setAvgTemp(findAvgValueInList(tempList));
+        dot.setMaxTemp(findMaxValueInList(tempList));
+        dot.setMinTemp(findMinValueInList(tempList));
 
-        dot.setAvgVibration(findAvgValueInMap(vibList));
-        dot.setMaxVibration(findMaxValueInMap(vibList));
-        dot.setMinVibration(findMinValueInMap(vibList));
+        dot.setAvgVibration(findAvgValueInList(vibList));
+        dot.setMaxVibration(findMaxValueInList(vibList));
+        dot.setMinVibration(findMinValueInList(vibList));
 
-        dot.setAvgHumidity(findAvgValueInMap(humList));
-        dot.setMaxHumidity(findMaxValueInMap(humList));
-        dot.setMinHumidity(findMinValueInMap(humList));
+        dot.setAvgHumidity(findAvgValueInList(humList));
+        dot.setMaxHumidity(findMaxValueInList(humList));
+        dot.setMinHumidity(findMinValueInList(humList));
 
         double oee = calculateOee(batchData.getAmountToProduce(), batchData.getDesiredSpeed(), Products.values()[batchData.getProductType()].speedLimit, machineData.get(machineData.size() - 1).getAcceptableProducts());
         dot.setOee(oee);

--- a/BrewMesModulesParent/batch/src/main/java/com/brewmes/batch/PrepareData.java
+++ b/BrewMesModulesParent/batch/src/main/java/com/brewmes/batch/PrepareData.java
@@ -5,16 +5,13 @@ import com.brewmes.common.entities.MachineData;
 import com.brewmes.common.services.IBatchReportService;
 import com.brewmes.common.util.Products;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 public abstract class PrepareData implements IBatchReportService {
-    private double calculateOee(int amountToProduce, double machineSpeed,  int maxMachineSpeed, int acceptedProducts) {
+    private double calculateOee(int amountToProduce, double machineSpeed, int maxMachineSpeed, int acceptedProducts) {
         double plannedProductionTime = (amountToProduce / machineSpeed) * 60;
-        double idealCycleTime = (1.0/maxMachineSpeed) * 60;
+        double idealCycleTime = (1.0 / maxMachineSpeed) * 60;
         return ((acceptedProducts * idealCycleTime) / plannedProductionTime) * 100;
     }
 
@@ -33,6 +30,7 @@ public abstract class PrepareData implements IBatchReportService {
 
     /**
      * Prepares the data for the IBatchReportService
+     *
      * @param batchData The Batch object to be calculated on.
      * @return {@code DataOverTime} object with the calculated values.
      */
@@ -62,7 +60,7 @@ public abstract class PrepareData implements IBatchReportService {
         dot.setMaxHumidity(findMaxValueInMap(humList));
         dot.setMinHumidity(findMinValueInMap(humList));
 
-        double oee = calculateOee(batchData.getAmountToProduce(), batchData.getDesiredSpeed(), Products.values()[batchData.getProductType()].speedLimit, machineData.get(machineData.size()-1).getAcceptableProducts());
+        double oee = calculateOee(batchData.getAmountToProduce(), batchData.getDesiredSpeed(), Products.values()[batchData.getProductType()].speedLimit, machineData.get(machineData.size() - 1).getAcceptableProducts());
         dot.setOee(oee);
 
         return dot;


### PR DESCRIPTION
Closes #

## Description
Fixes setter methods in prepareData.
They now take a list of doubles instead of a map with timestamps and doubles.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes, if necessary.
- [x] All tests pass (existing and potentially new).
- [x] Sonar check has passed
- [x] No code smells or bugs

## Other Relevant Information
Provide any other important details below.
