### PR TITLE
Make endpoint to GET MachineState

### DIFF
--- a/BrewMesModulesParent/api/src/main/java/com/brewmes/api/MachineController.java
+++ b/BrewMesModulesParent/api/src/main/java/com/brewmes/api/MachineController.java
@@ -9,6 +9,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -83,7 +84,9 @@ public class MachineController {
 
             statesObject.add("states", array);
 
-            return new ResponseEntity<>(statesObject.toString(), HttpStatus.OK);
+            HttpHeaders headers = new HttpHeaders(); //NOSONAR
+            headers.add("Content-Type","application/json");
+            return new ResponseEntity<>(statesObject.toString(), headers, HttpStatus.OK);
         } else {
             return new ResponseEntity<>("Could not get states", HttpStatus.NOT_FOUND);
         }

--- a/BrewMesModulesParent/api/src/main/java/com/brewmes/api/MachineController.java
+++ b/BrewMesModulesParent/api/src/main/java/com/brewmes/api/MachineController.java
@@ -3,6 +3,7 @@ package com.brewmes.api;
 import com.brewmes.common.entities.Connection;
 import com.brewmes.common.services.IMachineService;
 import com.brewmes.common.util.Command;
+import com.brewmes.common.util.MachineState;
 import com.brewmes.common.util.Products;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -62,6 +63,29 @@ public class MachineController {
             return new ResponseEntity<>(productsObject.toString(), HttpStatus.OK);
         } else {
             return new ResponseEntity<>("Could not get products", HttpStatus.NOT_FOUND);
+        }
+    }
+
+    @GetMapping("/states")
+    public ResponseEntity<Object> getStates() {
+        List<MachineState> states = machineService.getStates();
+        if (states != null) {
+            JsonObject statesObject = new JsonObject();
+            JsonArray array = new JsonArray();
+
+            for (MachineState state : states) {
+                JsonObject item = new JsonObject();
+                item.addProperty("name", state.state);
+                item.addProperty("value", state.value);
+
+                array.add(item);
+            }
+
+            statesObject.add("states", array);
+
+            return new ResponseEntity<>(statesObject.toString(), HttpStatus.OK);
+        } else {
+            return new ResponseEntity<>("Could not get states", HttpStatus.NOT_FOUND);
         }
     }
 

--- a/BrewMesModulesParent/api/src/test/java/com/brewmes/api/MachineControllerTest.java
+++ b/BrewMesModulesParent/api/src/test/java/com/brewmes/api/MachineControllerTest.java
@@ -3,6 +3,7 @@ package com.brewmes.api;
 import com.brewmes.common.entities.Connection;
 import com.brewmes.common.services.IMachineService;
 import com.brewmes.common.util.Command;
+import com.brewmes.common.util.MachineState;
 import com.brewmes.common.util.Products;
 import com.google.gson.JsonObject;
 import org.junit.jupiter.api.BeforeAll;
@@ -27,6 +28,7 @@ class MachineControllerTest {
     private static final JsonObject jsonObject = new JsonObject();
     private static final Connection connection = new Connection("T-800", "1.1.1.1", "Arnold");
     private static List<Products> productsList;
+    private static List<MachineState> stateList;
     @Mock
     IMachineService machineService;
     @InjectMocks
@@ -44,6 +46,7 @@ class MachineControllerTest {
         jsonObject.addProperty("batchSize", BatchSize);
 
         productsList = Arrays.asList(Products.values());
+        stateList = Arrays.asList(MachineState.values());
     }
 
     @Test
@@ -88,6 +91,24 @@ class MachineControllerTest {
         Mockito.when(machineService.getProducts()).thenReturn(null);
 
         ResponseEntity<Object> response = machineController.getProducts();
+
+        assertEquals(404, response.getStatusCodeValue());
+    }
+
+    @Test
+    void getStates_success(){
+        Mockito.when(machineService.getStates()).thenReturn(stateList);
+
+        ResponseEntity<Object> response = machineController.getStates();
+
+        assertEquals(200, response.getStatusCodeValue());
+    }
+
+    @Test
+    void getStates_failure(){
+        Mockito.when(machineService.getStates()).thenReturn(null);
+
+        ResponseEntity<Object> response = machineController.getStates();
 
         assertEquals(404, response.getStatusCodeValue());
     }

--- a/BrewMesModulesParent/common/src/main/java/com/brewmes/common/services/IMachineService.java
+++ b/BrewMesModulesParent/common/src/main/java/com/brewmes/common/services/IMachineService.java
@@ -2,6 +2,7 @@ package com.brewmes.common.services;
 
 import com.brewmes.common.entities.Connection;
 import com.brewmes.common.util.Command;
+import com.brewmes.common.util.MachineState;
 import com.brewmes.common.util.Products;
 
 import java.util.List;
@@ -50,6 +51,13 @@ public interface IMachineService {
      * @return a {@code List} of {@code Products} if the request was successful; {@code null} if not
      */
     List<Products> getProducts();
+
+    /**
+     * Gets a list of machine states, so the string can be mapped to an integer
+     *
+     * @return a {@code List} of {@code MachineStates} if the request was successful; {@code null} if not
+     */
+    List<MachineState> getStates();
 
     /**
      * Adds a connection to a Machine

--- a/BrewMesModulesParent/machine/src/main/java/com/brewmes/machine/MachineServiceImpl.java
+++ b/BrewMesModulesParent/machine/src/main/java/com/brewmes/machine/MachineServiceImpl.java
@@ -5,6 +5,7 @@ import com.brewmes.common.services.IMachineService;
 import com.brewmes.common.services.IScheduleService;
 import com.brewmes.common.services.ISubscribeService;
 import com.brewmes.common.util.Command;
+import com.brewmes.common.util.MachineState;
 import com.brewmes.common.util.Products;
 import com.brewmes.common.util.machinenodes.CommandNodes;
 import com.brewmes.common_repository.ConnectionRepository;
@@ -156,6 +157,11 @@ public class MachineServiceImpl implements IMachineService {
     @Override
     public List<Products> getProducts() {
         return new ArrayList<>(Arrays.asList(Products.values()));
+    }
+
+    @Override
+    public List<MachineState> getStates() {
+        return new ArrayList<>(Arrays.asList(MachineState.values()));
     }
 
     @Override

--- a/BrewMesModulesParent/machine/src/test/java/com/brewmes/machine/MachineServiceImplTest.java
+++ b/BrewMesModulesParent/machine/src/test/java/com/brewmes/machine/MachineServiceImplTest.java
@@ -2,6 +2,7 @@ package com.brewmes.machine;
 
 import com.brewmes.common.entities.Connection;
 import com.brewmes.common.util.Command;
+import com.brewmes.common.util.MachineState;
 import com.brewmes.common.util.Products;
 import com.brewmes.common_repository.ConnectionRepository;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
@@ -226,5 +227,30 @@ class MachineServiceImplTest {
         expected.add(Products.ALCOHOL_FREE);
 
         assertEquals(expected, machineService.getProducts());
+    }
+
+    @Test
+    void getStates() {
+        List<MachineState> expected = new ArrayList<>();
+
+        expected.add(MachineState.DEACTIVATED);
+        expected.add(MachineState.CLEARING);
+        expected.add(MachineState.STOPPED);
+        expected.add(MachineState.STARTING);
+        expected.add(MachineState.IDLE);
+        expected.add(MachineState.SUSPENDED);
+        expected.add(MachineState.EXECUTE);
+        expected.add(MachineState.STOPPING);
+        expected.add(MachineState.ABORTING);
+        expected.add(MachineState.ABORTED);
+        expected.add(MachineState.HOLDING);
+        expected.add(MachineState.HELD);
+        expected.add(MachineState.RESETTING);
+        expected.add(MachineState.COMPLETING);
+        expected.add(MachineState.COMPLETE);
+        expected.add(MachineState.DEACTIVATING);
+        expected.add(MachineState.ACTIVATING);
+
+        assertEquals(expected, machineService.getStates());
     }
 }


### PR DESCRIPTION
Closes #118 

## Description
It is not possible to make a graph with strings as y-values, therefore we need the enum to make the string value to an integer.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes, if necessary.
- [x] All tests pass (existing and potentially new).
- [x] Sonar check has passed
- [x] No code smells or bugs

## Other Relevant Information
