### PR TITLE
Fix batch not saving the last machineData properly

### DIFF
--- a/BrewMesModulesParent/subscriber/src/main/java/com/brewmes/subscriber/Subscription.java
+++ b/BrewMesModulesParent/subscriber/src/main/java/com/brewmes/subscriber/Subscription.java
@@ -186,11 +186,6 @@ public class Subscription implements Runnable {
                     this.currentBatch.setData(new ArrayList<>());
                     this.currentBatch.setDesiredSpeed(this.desiredSpeed);
                 }
-                // if state is == 17. Save batch and remove the object reference.
-                else if ((state == MachineState.COMPLETE || state == MachineState.ABORTED || state == MachineState.STOPPED) && currentBatch != null) {
-                    this.saveBatch();
-                    this.currentBatch = null;
-                }
             }
             // status nodes written to batch, if it exists.
             else if (StatusNodes.PRODUCTS_IN_CURRENT_BATCH.nodeId.toParseableString().equals(id) && currentBatch != null) {
@@ -222,6 +217,12 @@ public class Subscription implements Runnable {
 
         if (this.currentBatch != null) {
             this.saveBatch();
+
+            // if state is == 17 remove the object reference.
+            MachineState state = latestMachineData.getState();
+            if ((state == MachineState.COMPLETE || state == MachineState.ABORTED || state == MachineState.STOPPED)) {
+                this.currentBatch = null;
+            }
         }
     }
 

--- a/BrewMesModulesParent/subscriber/src/main/java/com/brewmes/subscriber/Subscription.java
+++ b/BrewMesModulesParent/subscriber/src/main/java/com/brewmes/subscriber/Subscription.java
@@ -218,7 +218,7 @@ public class Subscription implements Runnable {
         if (this.currentBatch != null) {
             this.saveBatch();
 
-            // if state is == 17 remove the object reference.
+            // if state == 17, 9, or 2, remove the object reference.
             MachineState state = latestMachineData.getState();
             if ((state == MachineState.COMPLETE || state == MachineState.ABORTED || state == MachineState.STOPPED)) {
                 this.currentBatch = null;


### PR DESCRIPTION
Closes #138 

## Description
Subscription had a minor bug where the batch might not save the latest machineData properly. That should be fixed now with a change to when the Batch is cleared.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes, if necessary.
- [x] All tests pass (existing and potential new).
- [x] Sonar check has passed
- [x] No codesmells or bugs

## Other Relevant Information
Provide any other important details below.
