### PR TITLE
140 Change the API component annotation from @RestController to @Controller

### DIFF
--- a/BrewMesModulesParent/api/src/main/java/com/brewmes/api/BatchController.java
+++ b/BrewMesModulesParent/api/src/main/java/com/brewmes/api/BatchController.java
@@ -11,13 +11,14 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 
-@RestController
+@Controller
 @RequestMapping("/api/batches")
 @CrossOrigin(origins = "http://localhost:3000")
 public class BatchController {

--- a/BrewMesModulesParent/api/src/main/java/com/brewmes/api/MachineController.java
+++ b/BrewMesModulesParent/api/src/main/java/com/brewmes/api/MachineController.java
@@ -12,13 +12,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.util.List;
 import java.util.Optional;
 
-@RestController
+@Controller
 @RequestMapping(value = "/api/machines")
 @CrossOrigin(origins = "http://localhost:3000")
 public class MachineController {

--- a/BrewMesModulesParent/api/src/main/java/com/brewmes/api/ScheduleController.java
+++ b/BrewMesModulesParent/api/src/main/java/com/brewmes/api/ScheduleController.java
@@ -5,13 +5,14 @@ import com.brewmes.common.services.IScheduleService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.util.Arrays;
 import java.util.List;
 
-@RestController
+@Controller
 @RequestMapping("/api/scheduled-batches")
 @CrossOrigin(origins = "http://localhost:3000")
 public class ScheduleController {


### PR DESCRIPTION
Closes #140

## Description
Changes the `@RestController` annotations in the API module to `@Controller`. 

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes, if necessary.
- [x] All tests pass (existing and potential new).
- [x] Sonar check has passed
- [x] No codesmells or bugs

## Other Relevant Information
Provide any other important details below.
