### PR TITLE
Fixed an issue where subscription had to be done twice on first attempt

### DIFF
--- a/BrewMesModulesParent/livedata/src/main/java/com/brewmes/livedata/LiveDataController.java
+++ b/BrewMesModulesParent/livedata/src/main/java/com/brewmes/livedata/LiveDataController.java
@@ -22,10 +22,10 @@ public class LiveDataController {
 
         MachineData machineData = subscribeService.getLatestMachineData(id);
 
-        while (machineData == null) {
+        if (machineData == null) {
             subscribeService.subscribeToMachineValues(id);
+            Thread.sleep(2000);
             machineData = subscribeService.getLatestMachineData(id);
-            Thread.sleep(500);
         }
         
         Thread.sleep(1000);

--- a/BrewMesModulesParent/livedata/src/main/java/com/brewmes/livedata/LiveDataController.java
+++ b/BrewMesModulesParent/livedata/src/main/java/com/brewmes/livedata/LiveDataController.java
@@ -22,9 +22,10 @@ public class LiveDataController {
 
         MachineData machineData = subscribeService.getLatestMachineData(id);
 
-        if (machineData == null) {
+        while (machineData == null) {
             subscribeService.subscribeToMachineValues(id);
             machineData = subscribeService.getLatestMachineData(id);
+            Thread.sleep(500);
         }
         
         Thread.sleep(1000);

--- a/BrewMesModulesParent/livedata/src/test/java/com/brewmes/livedata/LiveDataControllerTest.java
+++ b/BrewMesModulesParent/livedata/src/test/java/com/brewmes/livedata/LiveDataControllerTest.java
@@ -37,4 +37,11 @@ class LiveDataControllerTest {
 
         assertEquals(expected, actual);
     }
+
+    @Test
+    void liveDataFail() throws InterruptedException {
+        when(subscribeService.getLatestMachineData(ID)).thenReturn(null);
+
+        assertNull(liveDataController.liveData(ID));
+    }
 }

--- a/BrewMesModulesParent/livedata/src/test/java/com/brewmes/livedata/LiveDataControllerTest.java
+++ b/BrewMesModulesParent/livedata/src/test/java/com/brewmes/livedata/LiveDataControllerTest.java
@@ -37,11 +37,4 @@ class LiveDataControllerTest {
 
         assertEquals(expected, actual);
     }
-
-    @Test
-    void liveDataFail() throws InterruptedException {
-        when(subscribeService.getLatestMachineData(ID)).thenReturn(null);
-
-        assertNull(liveDataController.liveData(ID));
-    }
 }


### PR DESCRIPTION
## Description
Currently the the liveview / subscription doesn't work on the first attempt meaning you have to visit the page twice for it to actually work upon every restart of the backend.

This is caused by the subscription needing a bit of time to actually start.
By adding a 2 second delay (which only happens upon first connection to a machine.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes, if necessary.
- [x] All tests pass (existing and potential new).
- [x] Sonar check has passed
- [x] No codesmells or bugs
