### PR TITLE
Fix nullpointer in newest-batch-of-machine endpoint

### DIFF
--- a/BrewMesModulesParent/batch/src/main/java/com/brewmes/batch/BatchGetterImpl.java
+++ b/BrewMesModulesParent/batch/src/main/java/com/brewmes/batch/BatchGetterImpl.java
@@ -23,7 +23,7 @@ public class BatchGetterImpl implements IBatchGetterService {
     public Batch getStaticBatchVariables(String id) {
         List<Batch> batchList = batchRepository.findByConnectionID(id);
 
-        if (batchList != null) {
+        if (batchList != null && !batchList.isEmpty()) {
             Collections.reverse(batchList);
             Batch returnBatch = new Batch();
             returnBatch.setID(batchList.get(0).getID());

--- a/BrewMesModulesParent/batch/src/test/java/com/brewmes/batch/BatchGetterImplTest.java
+++ b/BrewMesModulesParent/batch/src/test/java/com/brewmes/batch/BatchGetterImplTest.java
@@ -62,9 +62,15 @@ class BatchGetterImplTest {
     }
 
     @Test
-    void getStaticBatchVariables_failure() {
+    void getStaticBatchVariables_failureNull() {
         Mockito.when(batchRepository.findByConnectionID("connectionID")).thenReturn(null);
 
+        assertNull(batchGetterService.getStaticBatchVariables("connectionID"));
+    }
+
+    @Test
+    void getStaticBatchVariables_FailureEmptyList() {
+        Mockito.when(batchRepository.findByConnectionID("connectionID")).thenReturn(new ArrayList<>());
         assertNull(batchGetterService.getStaticBatchVariables("connectionID"));
     }
 }


### PR DESCRIPTION
Closes #

## Description
Fixes a `NullPointerException` when requesting the end endpoint **`api/batches/newest-batch-of-machine/{id}`** and the requested machine does not have any batches produces yet. 

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes, if necessary.
- [x] All tests pass (existing and potential new).
- [] Sonar check has passed
- [x] No codesmells or bugs

## Other Relevant Information
Provide any other important details below.
